### PR TITLE
Bug Fixed in #Gather input features, predict structure

### DIFF
--- a/AlphaFold2.ipynb
+++ b/AlphaFold2.ipynb
@@ -294,7 +294,7 @@
         "  templates_result = template_featurizer.get_templates(query_sequence=query_sequence,\n",
         "                                                       query_pdb_code=None,\n",
         "                                                       query_release_date=None,\n",
-        "                                                       hhr_hits=hhsearch_hits)\n",
+        "                                                       hits=hhsearch_hits)\n",
         "  return templates_result.features\n",
         "\n",
         "def set_bfactor(pdb_filename, bfac, idx_res, chains):\n",


### PR DESCRIPTION
An error occurs when I run the pipeline.
TypeError: get_templates() got an unexpected keyword argument 'hhr_hits'

template_featurizer.get_templates() expects the variable called "hits" https://github.com/deepmind/alphafold/blob/0bab1bf84d9d887aba5cfb6d09af1e8c3ecbc408/alphafold/data/templates.py#L842