### PR TITLE
A small bug fixed when a custom alignment is provided

### DIFF
--- a/beta/AlphaFold_wJackhmmer.ipynb
+++ b/beta/AlphaFold_wJackhmmer.ipynb
@@ -438,7 +438,7 @@
         "  a3m_lines = []\n",
         "  for line in lines:\n",
         "    line = line.replace(\"\\x00\",\"\")\n",
-        "    if len(line) > 0:\n",
+        "    if len(line) > 0 and not line.startswith('#'):\n",
         "      a3m_lines.append(line)\n",
         "  msa, deletion_matrix = parsers.parse_a3m(\"\\n\".join(a3m_lines))\n",
         "  msas,deletion_matrices = [msa],[deletion_matrix]\n",


### PR DESCRIPTION
The MSA file generated by https://toolkit.tuebingen.mpg.de/tools/hhblits starts with '#A3M#'.  This raises an error in the parse_a3m module when a custom alignment is provided:

IndexError: list index out of range.

This fixes that little bug.
Best regards.
Enzo