### PR TITLE
Support multimer for FASTA input format

### DIFF
--- a/colabfold/batch.py
+++ b/colabfold/batch.py
@@ -299,9 +299,12 @@ def get_queries(
         elif input_path.suffix == ".fasta":
             (sequences, headers) = pipeline.parsers.parse_fasta(input_path.read_text())
             queries = [
-                (header, sequence.upper(), None)
+                (header, sequence.upper().split(":"), None)
                 for sequence, header in zip(sequences, headers)
             ]
+            for i in range(len(queries)):
+                if len(queries[i][1]) == 1:
+                    queries[i] = (queries[i][0], queries[i][1][0], None)
         else:
             raise ValueError(f"Unknown file format {input_path.suffix}")
     else:

--- a/colabfold_batch
+++ b/colabfold_batch
@@ -1,3 +1,7 @@
+"""
+A script just for myself to run directly from the repo, you can ignore this one.
+"""
+
 # -*- coding: utf-8 -*-
 import re
 import sys

--- a/colabfold_batch
+++ b/colabfold_batch
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+import re
+import sys
+from colabfold.batch import main
+if __name__ == '__main__':
+    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
+    sys.exit(main())


### PR DESCRIPTION
The multimer did not work me for FASTA input until I did this change (copying from the csv block).

You can ignore colabfold_batch but would be useful to have similar script in the top directory for those running from the repo.