### PR TITLE
fix fasta multimer input in CLI

### DIFF
--- a/colabfold/batch.py
+++ b/colabfold/batch.py
@@ -362,7 +362,7 @@ def get_queries(
             queries = []
             for sequence, header in zip(sequences, headers):
                 sequence = sequence.upper()
-                if sequence.count(":") == 1:
+                if sequence.count(":") == 0:
                     # Single sequence
                     queries.append((header, sequence, None))
                 else:


### PR DESCRIPTION
I am not 100% sure that this is a bug in `batch.py`. I _think_ the intent was to be able to model multimers with `.fasta` files formated like

```
>interesting_dimer
SEQUENCEA:SEQUENCEB
```

If this is the case, it was broken for dimeric complexes, but this pr should fix it. This has led to some confusion (see #97 for instance).