### PR TITLE
Add line enabling aliases expansion in setup_databases.sh

### DIFF
--- a/setup_databases.sh
+++ b/setup_databases.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Setup everything for using mmseqs locally
 
+shopt -s expand_aliases
+
 set -ex
 
 cd "$1"


### PR DESCRIPTION
I was unable to run `setup_databases.sh` as described in the README, due to the following error:
```bash
+ cd /data/work/colabfold/
++ command -v aria2c
+ '[' -x '' ']'
+ alias download=wget
+ '[' '!' -f UNIREF30_READY ']'
+ download http://wwwuser.gwdg.de/~compbiol/colabfold/uniref30_2103.tar.gz
./setup_databases.sh: line 15: download: command not found
```
I tried to run `shopt -s expand_aliases` in my bash shell before running
```bash
./setup_databases.sh /data/work/colabfold/
```
but it would still return the same error.  Instead, adding that line to the script itself, as per this PR, resolved the issue for me.

Btw, it seems that using aliases in scripts is somewhat discouraged, see e.g. https://unix.stackexchange.com/a/368258.