### PR TITLE
fixed naming of files when making zip

### DIFF
--- a/colabfold/batch.py
+++ b/colabfold/batch.py
@@ -1123,21 +1123,21 @@ def run(
             coverage_png,
             plddt_png,
         ]
-        for i in model_rank:
+        for i,key in enumerate(model_rank):
             result_files.append(
                 result_dir.joinpath(
-                    f"{jobname}_unrelaxed_rank_{i + 1}_{outs[i]['model_name']}.pdb"
+                    f"{jobname}_unrelaxed_rank_{i + 1}_{outs[key]['model_name']}.pdb"
                 )
             )
             result_files.append(
                 result_dir.joinpath(
-                    f"{jobname}_unrelaxed_rank_{i + 1}_{outs[i]['model_name']}_scores.json"
+                    f"{jobname}_unrelaxed_rank_{i + 1}_{outs[key]['model_name']}_scores.json"
                 )
             )
             if use_amber:
                 result_files.append(
                     result_dir.joinpath(
-                        f"{jobname}_relaxed_rank_{i + 1}_{outs[i]['model_name']}.pdb"
+                        f"{jobname}_relaxed_rank_{i + 1}_{outs[key]['model_name']}.pdb"
                     )
                 )
 

--- a/colabfold/batch.py
+++ b/colabfold/batch.py
@@ -1123,7 +1123,7 @@ def run(
             coverage_png,
             plddt_png,
         ]
-        for i,key in enumerate(model_rank):
+        for i, key in enumerate(model_rank):
             result_files.append(
                 result_dir.joinpath(
                     f"{jobname}_unrelaxed_rank_{i + 1}_{outs[key]['model_name']}.pdb"


### PR DESCRIPTION
I tried to run colab batch on complexes, but got an error saying "[Errno 2] No such file or directory" at line 1147 in batch.py:
`result_zip.write(file, arcname=file.name` 
It looks like the run function was not properly accounting for files (pdbs and jsons) that were renamed during ranking (it was directly reading out the index in model_rank instead of using the value as a key). I switched to enumerate (matching syntax in predict_structure, line 304 in batch.py), and that fixed the problem.