### PR TITLE
fix `setup_databases.sh` script silently continuing despite errors

### DIFF
--- a/setup_databases.sh
+++ b/setup_databases.sh
@@ -26,13 +26,13 @@ downloadFile() {
         ARIA)
             FILENAME=$(basename "${OUTPUT}")
             DIR=$(dirname "${OUTPUT}")
-            aria2c --max-connection-per-server="$ARIA_NUM_CONN" --allow-overwrite=true -o "$FILENAME" -d "$DIR" "$URL" && return 0
+            aria2c --max-connection-per-server="$ARIA_NUM_CONN" --allow-overwrite=true -o "$FILENAME" -d "$DIR" "$URL" && set -e && return 0
             ;;
         CURL)
-            curl -L -o "$OUTPUT" "$URL" && return 0
+            curl -L -o "$OUTPUT" "$URL" && set -e && return 0
             ;;
         WGET)
-            wget -O "$OUTPUT" "$URL" && return 0
+            wget -O "$OUTPUT" "$URL" && set -e && return 0
             ;;
         esac
     done


### PR DESCRIPTION
The `setup_databases.sh`  script may execute a command returning an error but the script would still continue, despite its intended design to stop  on any error.
The offending line is here: https://github.com/sokrypton/ColabFold/blob/b93680f62a305951cb7aa402903b34f595a6156a/setup_databases.sh#L23
`set +e` disables error checking but never turns it back on if download succeeded.
For example, the script may continue despite `mmseqs` being absent from the system or the wrong version is used, where `mmseqs` command(s) may silently not be properly executed, resulting in an incomplete database.
This PR restores correct behavior.