### PR TITLE
fixed a bug for pair_mode==unpaired 

### DIFF
--- a/colabfold/batch.py
+++ b/colabfold/batch.py
@@ -835,10 +835,16 @@ def generate_input_feature(
                     sequence, input_msa, template_features[sequence_index]
                 )
                 if is_complex:
+                    if paired_msa is None:
+                        input_msa = ">" + str(101 + sequence_index) + "\n" + sequence
+                    else:
+                        input_msa = paired_msa[sequence_index]
+
                     all_seq_features = build_multimer_feature(
-                        paired_msa[sequence_index]
+                        input_msa
                     )
                     feature_dict.update(all_seq_features)
+
                 features_for_chain[protein.PDB_CHAIN_IDS[chain_cnt]] = feature_dict
                 chain_cnt += 1
 

--- a/colabfold/batch.py
+++ b/colabfold/batch.py
@@ -840,9 +840,7 @@ def generate_input_feature(
                     else:
                         input_msa = paired_msa[sequence_index]
 
-                    all_seq_features = build_multimer_feature(
-                        input_msa
-                    )
+                    all_seq_features = build_multimer_feature(input_msa)
                     feature_dict.update(all_seq_features)
 
                 features_for_chain[protein.PDB_CHAIN_IDS[chain_cnt]] = feature_dict


### PR DESCRIPTION
It will resolve issues #191 and #181
I am not completely sure about which one would be the solution either this PR or
```python
                if is_complex and (paired_msa is not None):
                    all_seq_features = build_multimer_feature(
                        paired_msa[sequence_index]
                    )
                    feature_dict.update(all_seq_features)
```
When I tested this PR on Colab, it worked fine though. 