### PR TITLE
Update README.md to create a Python 3.7 environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@
 
 _Note: Checkout [localcolabfold](https://github.com/YoshitakaMo/localcolabfold) too
 
+It is recommended that you create a conda environment with python version 3.7. If you use a newer python version, you might run into problems when installing tensorflow, as the required version may not be found.
+
+```shell
+conda create --name my_colabfold python=3.7
+```
+Then activate it with `activate my_colabfold`.
+
 Install ColabFold using the `pip` commands below. `pip` will resolve and install all required dependencies and ColabFold should be ready within a few minutes to use. Please check the [JAX documentation](https://github.com/google/jax#pip-installation-gpu-cuda) for how to get JAX to work on your GPU or TPU.
 
 ```shell


### PR DESCRIPTION
Current conda python version 3.10 raises the following error during the installation:
```shell
ERROR: Could not find a version that satisfies the requirement tensorflow-cpu<2.8.0 (from colabfold[alphafold]) (from versions: 2.8.0, 2.8.1, 2.8.2, 2.9.0rc0, 2.9.0rc1, 2.9.0rc2, 2.9.0, 2.9.1)
ERROR: No matching distribution found for tensorflow-cpu<2.8.0
```