### PR TITLE
update uniref30db to 2202

### DIFF
--- a/colabfold/mmseqs/search.py
+++ b/colabfold/mmseqs/search.py
@@ -26,7 +26,7 @@ def run_mmseqs(mmseqs: Path, params: List[Union[str, Path]]):
 def mmseqs_search_monomer(
     dbbase: Path,
     base: Path,
-    uniref_db: Path = Path("uniref30_2103_db"),
+    uniref_db: Path = Path("uniref30_2202_db"),
     template_db: Path = Path(""),  # Unused by default
     metagenomic_db: Path = Path("colabfold_envdb_202108_db"),
     mmseqs: Path = Path("mmseqs"),

--- a/setup_databases.sh
+++ b/setup_databases.sh
@@ -41,10 +41,10 @@ downloadFile() {
 }
 
 if [ ! -f UNIREF30_READY ]; then
-  downloadFile "http://wwwuser.gwdg.de/~compbiol/colabfold/uniref30_2103.tar.gz" "uniref30_2103.tar.gz"
-  tar xzvf "uniref30_2103.tar.gz"
-  mmseqs tsv2exprofiledb "uniref30_2103" "uniref30_2103_db"
-  mmseqs createindex "uniref30_2103_db" tmp1 --remove-tmp-files 1
+  downloadFile "http://wwwuser.gwdg.de/~compbiol/colabfold/uniref30_2202.tar.gz" "uniref30_2202.tar.gz"
+  tar xzvf "uniref30_2202.tar.gz"
+  mmseqs tsv2exprofiledb "uniref30_2202" "uniref30_2202_db"
+  mmseqs createindex "uniref30_2202_db" tmp1 --remove-tmp-files 1
   touch UNIREF30_READY
 fi
 


### PR DESCRIPTION
Update the default UniRef database to [uniref30_2202.tar.gz](https://wwwuser.gwdg.de/~compbiol/colabfold/uniref30_2202.tar.gz) for local `colabfold_search`.