### PR TITLE
turn on template search for a3m input files

### DIFF
--- a/colabfold/batch.py
+++ b/colabfold/batch.py
@@ -356,7 +356,9 @@ def predict_structure(
 
         # The original alphafold only returns the prediction_result,
         # but our patched alphafold also returns a tuple (recycles,tol)
-        prediction_result, recycles = model_runner.predict(input_features, random_seed=random_seed)
+        prediction_result, recycles = model_runner.predict(
+            input_features, random_seed=random_seed
+        )
 
         prediction_time = time.time() - start
         prediction_times.append(prediction_time)
@@ -1316,13 +1318,31 @@ def run(
 
         try:
             if a3m_lines is not None:
-                (
-                    unpaired_msa,
-                    paired_msa,
-                    query_seqs_unique,
-                    query_seqs_cardinality,
-                    template_features,
-                ) = unserialize_msa(a3m_lines, query_sequence)
+                if use_templates is False:
+                    (
+                        unpaired_msa,
+                        paired_msa,
+                        query_seqs_unique,
+                        query_seqs_cardinality,
+                        template_features,
+                    ) = unserialize_msa(a3m_lines, query_sequence)
+                else:
+                    (
+                        unpaired_msa,
+                        paired_msa,
+                        query_seqs_unique,
+                        query_seqs_cardinality,
+                    ) = unserialize_msa(a3m_lines, query_sequence)[:4]
+                    template_features = get_msa_and_templates(
+                        jobname,
+                        query_sequence,
+                        result_dir,
+                        msa_mode,
+                        use_templates,
+                        custom_template_path,
+                        pair_mode,
+                        host_url,
+                    )[4]
             else:
                 (
                     unpaired_msa,


### PR DESCRIPTION
Currently, the template search is not working if the input file format is a3m even though `--templates` arg was added. This PR fixes the issue.