### PR TITLE
Rename `qdb.lookup` so that it will not be removed

### DIFF
--- a/colabfold/mmseqs/search.py
+++ b/colabfold/mmseqs/search.py
@@ -411,7 +411,7 @@ def main():
         args.mmseqs,
         ["createdb", query_file, args.base.joinpath("qdb"), "--shuffle", "0"],
     )
-    with args.base.joinpath("qdb.lookup").open("w") as f:
+    with args.base.joinpath("query.lookup").open("w") as f:
         id = 0
         file_number = 0
         for job_number, (


### PR DESCRIPTION
The colabfold.mmseqs.search.py generates a `qdb.lookup` to match queries and ids. This file is useful to map back the batched results. However, this file is removed by `mmseqs rmdb qdb`, which basically does `rm qdb*`. Renaming this file avoids this (potentially accidental) removing.
