### PR TITLE
fix a3m + template

### DIFF
--- a/colabfold/batch.py
+++ b/colabfold/batch.py
@@ -1399,15 +1399,19 @@ def run(
         # generate MSA (a3m_lines) and templates
         ###########################################
         try:
-            if use_templates or a3m_lines is None:
+            if a3m_lines is None: 
                 (unpaired_msa, paired_msa, query_seqs_unique, query_seqs_cardinality, template_features) \
                 = get_msa_and_templates(jobname, query_sequence, result_dir, msa_mode, use_templates, 
                     custom_template_path, pair_mode, host_url)
-            if a3m_lines is not None:
-                (unpaired_msa, paired_msa, query_seqs_unique, query_seqs_cardinality, template_features_) \
+            
+            elif a3m_lines is not None: 
+                (unpaired_msa, paired_msa, query_seqs_unique, query_seqs_cardinality, template_features) \
                 = unserialize_msa(a3m_lines, query_sequence)
-                if not use_templates: template_features = template_features_
-
+                if use_templates: 
+                    (_, _, _, _, template_features) \
+                        = get_msa_and_templates(jobname, query_seqs_unique, result_dir, 'single_sequence', use_templates, 
+                            custom_template_path, pair_mode, host_url)
+                        
             # save a3m
             msa = msa_to_str(unpaired_msa, paired_msa, query_seqs_unique, query_seqs_cardinality)
             result_dir.joinpath(f"{jobname}.a3m").write_text(msa)


### PR DESCRIPTION
This PR seeks to fix the interaction between specifying templates while using an a3m. Natively this breaks when the a3m contains a multimeric protein. As an example, an a3m generated from the following fasta fails when using the --templates flag:
`> 1QYS_1_Chain A_TOP7_ComputationallyDesignedSequence
AQAQAQTG:DGTLAVPFKAQAQTG:LECYQCYGVPFETSCPSITCPYPDGVCVTQEAAVIVDSQTRKVKNNLCLPICPPNIESMEILGTKVNVKTSCCQEDLCNVAVP` 

The bug occurs because when using an a3m file as well as templates, template features are generated for only the concatenated sequence as opposed to the individual chains. This causes a mismatch in the `generate_input_feature` call as the length of `template_features` is 1 while `query_seqs_unique` will have length equal to the number of chains. 

This fix splits the concatenated sequence before retrieving template features.
