### PR TITLE
Fix CFMMCIFIO _struct_asym.id values

### DIFF
--- a/colabfold/utils.py
+++ b/colabfold/utils.py
@@ -122,6 +122,10 @@ mmcif_order = {
 
 class CFMMCIFIO(MMCIFIO):
     def _save_dict(self, out_file):
+        asym_id_auth_to_label = dict(
+            zip(self.dic.get("_atom_site.auth_asym_id", ()),
+                self.dic.get("_atom_site.label_asym_id", ())))
+
         # Form dictionary where key is first part of mmCIF key and value is list
         # of corresponding second parts
         key_lists = {}
@@ -199,7 +203,8 @@ _struct_asym.entity_id
             chain_idx = 1
             for model in self.structure:
                 for chain in model:
-                    out_file.write(f"{chain.get_id()} {chain_idx}\n")
+                    label_asym_id = asym_id_auth_to_label[chain.get_id()]
+                    out_file.write(f"{label_asym_id} {chain_idx}\n")
                     chain_idx += 1
             out_file.write("#\n")
 


### PR DESCRIPTION
In `CFMMCIFIO` (which is used by `convert_pdb_to_mmcif`), map the chain ID to the `_atom_site.label_asym_id`, which corresponds to `_struct_asym.id`.

Should fix https://github.com/sokrypton/ColabFold/issues/449 and https://github.com/sokrypton/ColabFold/issues/469

@data2code @jkosinski