### PR TITLE
Fixed multimer msa not paired if raw_jobname has white spaces

### DIFF
--- a/colabfold/mmseqs/search.py
+++ b/colabfold/mmseqs/search.py
@@ -311,7 +311,8 @@ def main():
             query_seqs_cardinality,
         ) in enumerate(queries_unique):
             for seq in query_sequences:
-                f.write(f"{id}\t{raw_jobname}\t{file_number}\n")
+                raw_jobname_first = raw_jobname.split(" ")[0]
+                f.write(f"{id}\t{raw_jobname_first}\t{file_number}\n")
                 id += 1
             file_number += 1
 


### PR DESCRIPTION
Made qdb.lookup to only save first word of raw_jobname(header)