### PR TITLE
Adjust configuration to use PDB100 instead of PDB70 database

### DIFF
--- a/MsaServer/config.json
+++ b/MsaServer/config.json
@@ -16,9 +16,9 @@
             // this will ~2-3x speedup the execution, while requiring more cores
             "parallelstages": true,
             "uniref"        : "~/databases/uniref30_2202_db",
-            "pdb"           : "~/databases/pdb70_220313",
+            "pdb"           : "~/databases/pdb100_230517",
             "environmental" : "~/databases/colabfold_envdb_202108_db",
-            "pdb70"         : "~/databases/pdb70",
+            "pdb70"         : "~/databases/pdb100",
             "pdbdivided"    : "~/databases/pdb/divided",
             "pdbobsolete"   : "~/databases/pdb/obsolete"
         },


### PR DESCRIPTION
Hi,

I raised this pull request based on the following:
- My own experience with deploying the MsaServer
- The GitHub issue here: https://github.com/sokrypton/ColabFold/issues/502
- The thread in this issue here: https://github.com/soedinglab/hh-suite/issues/362
- The GitHub issue I raised here: https://github.com/sokrypton/ColabFold/issues/533

Please let me know if you feel this breaks functionality, I am happy to adjust. This is what worked for setting up the MsaServer and running the AlphaFold2 notebook based on latest notes and code in main
