### PR TITLE
Update utils.py

### DIFF
--- a/colabfold/utils.py
+++ b/colabfold/utils.py
@@ -205,8 +205,9 @@ _struct_asym.entity_id
             chain_idx = 1
             for model in self.structure:
                 for chain in model:
-                    label_asym_id = asym_id_auth_to_label[chain.get_id()]
-                    out_file.write(f"{label_asym_id} {chain_idx}\n")
+                    if chain.get_id() in asym_id_auth_to_label:
+                        label_asym_id = asym_id_auth_to_label[chain.get_id()]
+                        out_file.write(f"{label_asym_id} {chain_idx}\n")
                     chain_idx += 1
             out_file.write("#\n")
 


### PR DESCRIPTION

[7qvs_1927.pdb.txt](https://github.com/sokrypton/ColabFold/files/14240104/7qvs_1927.pdb.txt)
Make convert_pdb_to_mmcif() function work for custom templates with chains consisting only of HETATMs (chains 'B', 'C', 'E', 'F' for 7qvs_1927.pdb).  
ColabFold dies and throws a KeyError:

  File "ColabFold/colabfold/utils.py", line 208, in _save_dict
    label_asym_id = asym_id_auth_to_label[chain.get_id()]
KeyError: 'B'