### PR TITLE
Add Initial Guess Feature

### DIFF
--- a/colabfold/batch.py
+++ b/colabfold/batch.py
@@ -647,7 +647,7 @@ def parse_fasta(fasta_string: str) -> Tuple[List[str], List[str]]:
     return sequences, descriptions
 
 def parse_pdb(pdb_string: str) -> List[str]:
-    """Parses a PDB string and returns the sequence and a list of sequence descriptions.
+    """Parses a PDB string and returns a list of sequences.
 
     Arguments:
       pdb_string: The string contents of a PDB file.

--- a/colabfold/batch.py
+++ b/colabfold/batch.py
@@ -319,7 +319,11 @@ MODRES = {'MSE':'MET','MLY':'LYS','FME':'MET','HYP':'PRO',
           'TYS':'TYR','IAS':'ASP','GPL':'LYS','KYN':'TRP',
           'CSD':'CYS','SEC':'CYS'}
 
-def pdb_to_string(pdb_file, chains=None, models=None):
+def pdb_to_string(
+        pdb_file: str, 
+        chains: Optional[str] = None, 
+        models: Optional[list] = None
+    ) -> str:
   '''read pdb file and return as string'''
 
   if chains is not None:


### PR DESCRIPTION
Hi,

This pull request implements the `--initial-guess` feature, inspired by the functionality available in [ColabDesign](https://github.com/sokrypton/ColabDesign/commit/6f0a8763a533636e801935e90076c1a386c0ddba).

### Related issue: 
- #432

### Description:
- It enables the handling of `.pdb` inputs by parsing the pdb file and retrieving chain sequences
- The addition of the `--initial-guess` flag allows for the provision of initial guess `.pdb` input either as the main input or via the `--initial-guess` flag
- Minor adjustments to the Alphafold code have been made to accommodate this new feature - https://github.com/steineggerlab/alphafold/pull/8
