### PR TITLE
add environmental pairing feature

### DIFF
--- a/colabfold/mmseqs/search.py
+++ b/colabfold/mmseqs/search.py
@@ -178,12 +178,12 @@ def mmseqs_search_pair(
     uniref_db: Path = Path("uniref30_2302_db"),
     spire_db: Path = Path("spire_ctg10_2401_db"),
     mmseqs: Path = Path("mmseqs"),
+    pair_env: bool = True,
     prefilter_mode: int = 0,
     s: float = 8,
     threads: int = 64,
     db_load_mode: int = 2,
     pairing_strategy: int = 0,
-    pair_uniref: bool = True,
 ):
     if not dbbase.joinpath(f"{uniref_db}.dbtype").is_file():
         raise FileNotFoundError(f"Database {uniref_db} does not exist")
@@ -202,12 +202,12 @@ def mmseqs_search_pair(
         dbSuffix1 = ".idx"
         dbSuffix2 = ".idx"
 
-    if pair_uniref:
-        db = uniref_db
-        output = ".paired.uniref.a3m"
-    else:
+    if pair_env:
         db = spire_db
-        output = ".paired.spire.a3m"
+        output = ".env.paired.a3m"
+    else:
+        db = uniref_db
+        output = ".paired.a3m"
 
     # fmt: off
     # @formatter:off
@@ -218,16 +218,14 @@ def mmseqs_search_pair(
     else:
         search_param += ["--k-score", "'seq:96,prof:80'"]
     expand_param = ["--expansion-mode", "0", "-e", "inf", "--expand-filter-clusters", "0", "--max-seq-id", "0.95",]
-    run_mmseqs(mmseqs, ["search", base.joinpath("qdb"), dbbase.joinpath(uniref_db), base.joinpath("res"), base.joinpath("tmp"), "--threads", str(threads),] + search_param,)
-    run_mmseqs(mmseqs, ["expandaln", base.joinpath("qdb"), dbbase.joinpath(f"{uniref_db}{dbSuffix1}"), base.joinpath("res"), dbbase.joinpath(f"{uniref_db}{dbSuffix2}"), base.joinpath("res_exp"), "--db-load-mode", str(db_load_mode), "--threads", str(threads),] + expand_param,)
-    run_mmseqs(mmseqs, ["align", base.joinpath("qdb"), dbbase.joinpath(f"{uniref_db}{dbSuffix1}"), base.joinpath("res_exp"), base.joinpath("res_exp_realign"), "--db-load-mode", str(db_load_mode), "-e", "0.001", "--max-accept", "1000000", "--threads", str(threads), "-c", "0.5", "--cov-mode", "1",],)
-    run_mmseqs(mmseqs, ["pairaln", base.joinpath("qdb"), dbbase.joinpath(f"{uniref_db}"), base.joinpath("res_exp_realign"), base.joinpath("res_exp_realign_pair"), "--db-load-mode", str(db_load_mode), "--pairing-mode", str(pairing_strategy), "--pairing-dummy-mode", "0", "--threads", str(threads), ],)
-    run_mmseqs(mmseqs, ["align", base.joinpath("qdb"), dbbase.joinpath(f"{uniref_db}{dbSuffix1}"), base.joinpath("res_exp_realign_pair"), base.joinpath("res_exp_realign_pair_bt"), "--db-load-mode", str(db_load_mode), "-e", "inf", "-a", "--threads", str(threads), ],)
-    run_mmseqs(mmseqs, ["pairaln", base.joinpath("qdb"), dbbase.joinpath(f"{uniref_db}"), base.joinpath("res_exp_realign_pair_bt"), base.joinpath("res_final"), "--db-load-mode", str(db_load_mode), "--pairing-mode", str(pairing_strategy), "--pairing-dummy-mode", "1", "--threads", str(threads),],)
-    run_mmseqs(mmseqs, ["result2msa", base.joinpath("qdb"), dbbase.joinpath(f"{uniref_db}{dbSuffix1}"), base.joinpath("res_final"), base.joinpath("pair.a3m"), "--db-load-mode", str(db_load_mode), "--msa-format-mode", "5", "--threads", str(threads),],)
-    run_mmseqs(mmseqs, ["unpackdb", base.joinpath("pair.a3m"), base.joinpath("."), "--unpack-name-mode", "0", "--unpack-suffix", ".paired.a3m",],)
-    run_mmseqs(mmseqs, ["rmdb", base.joinpath("qdb")])
-    run_mmseqs(mmseqs, ["rmdb", base.joinpath("qdb_h")])
+    run_mmseqs(mmseqs, ["search", base.joinpath("qdb"), dbbase.joinpath(db), base.joinpath("res"), base.joinpath("tmp"), "--threads", str(threads),] + search_param,)
+    run_mmseqs(mmseqs, ["expandaln", base.joinpath("qdb"), dbbase.joinpath(f"{db}{dbSuffix1}"), base.joinpath("res"), dbbase.joinpath(f"{db}{dbSuffix2}"), base.joinpath("res_exp"), "--db-load-mode", str(db_load_mode), "--threads", str(threads),] + expand_param,)
+    run_mmseqs(mmseqs, ["align", base.joinpath("qdb"), dbbase.joinpath(f"{db}{dbSuffix1}"), base.joinpath("res_exp"), base.joinpath("res_exp_realign"), "--db-load-mode", str(db_load_mode), "-e", "0.001", "--max-accept", "1000000", "--threads", str(threads), "-c", "0.5", "--cov-mode", "1",],)
+    run_mmseqs(mmseqs, ["pairaln", base.joinpath("qdb"), dbbase.joinpath(f"{db}"), base.joinpath("res_exp_realign"), base.joinpath("res_exp_realign_pair"), "--db-load-mode", str(db_load_mode), "--pairing-mode", str(pairing_strategy), "--pairing-dummy-mode", "0", "--threads", str(threads), ],)
+    run_mmseqs(mmseqs, ["align", base.joinpath("qdb"), dbbase.joinpath(f"{db}{dbSuffix1}"), base.joinpath("res_exp_realign_pair"), base.joinpath("res_exp_realign_pair_bt"), "--db-load-mode", str(db_load_mode), "-e", "inf", "-a", "--threads", str(threads), ],)
+    run_mmseqs(mmseqs, ["pairaln", base.joinpath("qdb"), dbbase.joinpath(f"{db}"), base.joinpath("res_exp_realign_pair_bt"), base.joinpath("res_final"), "--db-load-mode", str(db_load_mode), "--pairing-mode", str(pairing_strategy), "--pairing-dummy-mode", "1", "--threads", str(threads),],)
+    run_mmseqs(mmseqs, ["result2msa", base.joinpath("qdb"), dbbase.joinpath(f"{db}{dbSuffix1}"), base.joinpath("res_final"), base.joinpath("pair.a3m"), "--db-load-mode", str(db_load_mode), "--msa-format-mode", "5", "--threads", str(threads),],)
+    run_mmseqs(mmseqs, ["unpackdb", base.joinpath("pair.a3m"), base.joinpath("."), "--unpack-name-mode", "0", "--unpack-suffix", output,],)
     run_mmseqs(mmseqs, ["rmdb", base.joinpath("res")])
     run_mmseqs(mmseqs, ["rmdb", base.joinpath("res_exp")])
     run_mmseqs(mmseqs, ["rmdb", base.joinpath("res_exp_realign")])
@@ -238,27 +236,6 @@ def mmseqs_search_pair(
     shutil.rmtree(base.joinpath("tmp"))
     # @formatter:on
     # fmt: on
-
-def merge_a3ms(
-    a3m_uniref: Path,
-    a3m_spire: Path,
-    a3m_merged: Path,
-):
-    # copy uniref a3m to merged a3m
-    shutil.copy(a3m_uniref, a3m_merged)
-    # append spire a3m to merged a3m, skipping the first FASTA entry
-    with open(a3m_merged, "a") as f:
-        first = True
-        flag = False
-        with open(a3m_spire, "r") as g:
-            while buf := g.readline():
-                if buf.startswith(">") and first:
-                    first = False
-                    continue
-                elif buf.startswith(">") and not first:
-                    flag = True
-                if flag:
-                    f.write(buf)
 
 def main():
     parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
@@ -307,10 +284,10 @@ def main():
         "--use-env", type=int, default=1, choices=[0, 1], help="Use --db3"
     )
     parser.add_argument(
-        "--use-templates", type=int, default=0, choices=[0, 1], help="Use --db2"
+        "--use-env-pairing", type=int, default=0, choices=[0, 1], help="Use --db4"
     )
     parser.add_argument(
-        "--use-env-pairing", type=int, default=0, choices=[0, 1], help="Use --db4"
+        "--use-templates", type=int, default=0, choices=[0, 1], help="Use --db2"
     )
     parser.add_argument(
         "--filter",
@@ -451,7 +428,7 @@ def main():
             db_load_mode=args.db_load_mode,
             threads=args.threads,
             pairing_strategy=args.pairing_strategy,
-            pair_uniref=True,
+            pair_env=False,
         )
         if args.use_env_pairing:
             mmseqs_search_pair(
@@ -465,7 +442,7 @@ def main():
                 db_load_mode=args.db_load_mode,
                 threads=args.threads,
                 pairing_strategy=args.pairing_strategy,
-                pair_uniref=False,
+                pair_env=True,
             )
 
         id = 0
@@ -484,11 +461,11 @@ def main():
                 args.base.joinpath(f"{id}.a3m").unlink()
 
                 if args.use_env_pairing:
-                    merge_a3ms(args.base.joinpath(f"{id}.paired.uniref.a3m"), args.base.joinpath(f"{id}.paired.spire.a3m"), args.base.joinpath(f"{id}.paired.a3m"))
-                    args.base.joinpath(f"{id}.paired.spire.a3m").unlink()
-                else:
-                    shutil.copy(args.base.joinpath(f"{id}.paired.uniref.a3m"), args.base.joinpath(f"{id}.paired.a3m"))
-                args.base.joinpath(f"{id}.paired.uniref.a3m").unlink()
+                    with open(args.base.joinpath(f"{id}.paired.a3m"), 'a') as file_pair:
+                        with open(args.base.joinpath(f"{id}.env.paired.a3m"), 'r') as file_pair_env:
+                            while chunk := file_pair_env.read(10 * 1024 * 1024):
+                                file_pair.write(chunk)
+                    args.base.joinpath(f"{id}.env.paired.a3m").unlink()
 
                 if len(query_seqs_cardinality) > 1:
                     with args.base.joinpath(f"{id}.paired.a3m").open("r") as f:


### PR DESCRIPTION
This introduces the environmental pairing strategy built upon SPIRE metagenomic database contig labels.
Addition of the database `spire_ctg10_2401_db` must be accompanied to run this feature properly.
My original intention was to set `--use-env-pairing 1` as a default parameter, however, I found it better to keep it zero until a proper establishment of this feature being made.