### PR TITLE
Fixing biopython compatibility issue by reverting to 1.81

### DIFF
--- a/beta/omegafold.ipynb
+++ b/beta/omegafold.ipynb
@@ -62,7 +62,7 @@
         "    if not os.path.isdir(\"OmegaFold\"):\n",
         "      %shell git clone --branch beta --quiet https://github.com/sokrypton/OmegaFold.git\n",
         "      # %shell cd OmegaFold; pip -q install -r requirements.txt\n",
-        "      %shell pip -q install py3Dmol biopython\n",
+        "      %shell pip -q install py3Dmol biopython==1.81\n",
         "      %shell apt-get install aria2 -qq > /dev/null\n",
         "      %shell aria2c -q -x 16 https://helixon.s3.amazonaws.com/release1.pt\n",
         "      %shell mkdir -p ~/.cache/omegafold_ckpt\n",


### PR DESCRIPTION
The existing version of the OmegaFold notebook on the ColabFold repository doesn't work because of compatibility issues with biopython. Reverting to biopython 1.81 during installation fixes the issue. The maintainers would have to update the link to the colab notebook, so that this change can be reflected for those trying to run this on Google Colab.

The original line:
``%shell pip -q install py3Dmol biopython``
is updated to:
``%shell pip -q install py3Dmol biopython``
in the installation block of the OmegaFold notebook located at ColabFold/beta/omegafold.ipynb