### PR TITLE
removed ,<3.12 for causing installation issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.12"
+python = ">=3.9"
 absl-py = "^1.0.0"
 jax = { version = "^0.4.20", optional = true }
 matplotlib = "^3.2.2"


### PR DESCRIPTION
The <3.12 python version check was making it impossible to install the package on Linux distributions that use newer versions of python by default. Can confirm that the ColabFold package installs perfectly on current latest versions of python and the check in my opinion is unnecessary.