### PR TITLE
Support `aarch64` with pip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ absl-py = "^1.0.0"
 jax = { version = "^0.4.20", optional = true }
 matplotlib = "^3.2.2"
 tensorflow-macos = { version = "<2.14.0", markers = "sys_platform == 'darwin'" }
-tensorflow-cpu = { version = "^2.12.1", markers = "sys_platform != 'darwin'" }
+tensorflow = { version = "^2.12.1", markers = "sys_platform != 'darwin'" }
 biopython = "<1.83"
 numpy = "^1.22.0"
 pandas = "^1.3.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ absl-py = "^1.0.0"
 jax = { version = "^0.4.20", optional = true }
 matplotlib = "^3.2.2"
 tensorflow-macos = { version = "<2.14.0", markers = "sys_platform == 'darwin'" }
-tensorflow = { version = "^2.12.1", markers = "sys_platform != 'darwin'" }
+tensorflow-cpu = { version = "^2.12.1", markers = "sys_platform != 'darwin' and platform_machine != 'aarch64'" }
+tensorflow = { version = "^2.12.1", markers = "sys_platform != 'darwin' and platform_machine == 'aarch64'" }
 biopython = "<1.83"
 numpy = "^1.22.0"
 pandas = "^1.3.4"


### PR DESCRIPTION
This is a minimal PR changing `tensorflow-cpu -> tensorflow` in `pyproject.toml` as Tensorflow does not build wheels of tensorflow-cpu for Arm. 

See #637 for more details.

@milot-mirdita Do you think there is a better way to overcome thi?