### PR TITLE
fix: update Dockerfile to use Miniforge3 instead of Mambaforge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM nvidia/cuda:${CUDA_VERSION}-base-ubuntu22.04
 RUN apt-get update && apt-get install -y wget cuda-nvcc-$(echo $CUDA_VERSION | cut -d'.' -f1,2 | tr '.' '-') --no-install-recommends --no-install-suggests && rm -rf /var/lib/apt/lists/* && \
     wget -qnc https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh && \
     bash Miniforge3-Linux-x86_64.sh -bfp /usr/local && \
-    mamba config --set auto_update_conda false && \
+    conda config --set auto_update_conda false && \
     rm -f Miniforge3-Linux-x86_64.sh && \
     CONDA_OVERRIDE_CUDA=$(echo $CUDA_VERSION | cut -d'.' -f1,2) mamba create -y -n colabfold -c conda-forge -c bioconda colabfold=$COLABFOLD_VERSION jaxlib==*=cuda* && \
     mamba clean -afy


### PR DESCRIPTION
This pull request updates the Dockerfile to use Miniforge3 instead of Mambaforge for installing the conda environment since [conda-forge has deprecated Mambaforge](https://github.com/conda-forge/miniforge?tab=readme-ov-file#should-i-choose-one-or-another-going-forward-at-the-risk-of-one-of-them-getting-deprecated).

Dependency management update:

* Switched from downloading and installing `Mambaforge-Linux-x86_64.sh` to `Miniforge3-Linux-x86_64.sh`, updating all related commands and cleanup steps in the Dockerfile.