### PR TITLE
Corrected checking wrong argument

### DIFF
--- a/colabfold/mmseqs/search.py
+++ b/colabfold/mmseqs/search.py
@@ -537,7 +537,7 @@ def main():
                 for seq in query_sequences:
                     with args.base.joinpath(f"{id}.a3m").open("r") as f:
                         unpaired_msa.append(f.read())
-                    if args.af3_json:
+                    if args.unpack:
                         args.base.joinpath(f"{id}.a3m").unlink()
 
                     if args.use_env_pairing:


### PR DESCRIPTION
Due to the mistake I made implementing AF3-json format, some intermediate msa files remain undeleted after colabfold_search. I corrected it to check unpack argument instead and now all the intermediate msas are deleted.