### PR TITLE
Change SUBSET value from 10 to 1010

### DIFF
--- a/setup_databases.sh
+++ b/setup_databases.sh
@@ -121,7 +121,7 @@ if [ -n "${GPU}" ]; then
   SUBSET=2
   # recent mmseqs versions also allow dropping the sequence lookup, which is not used in GPU
   if mmseqs indexdb --help | grep -q "8: no sequence lookup"; then
-    SUBSET=10
+    SUBSET=1010
   fi
   GPU_INDEX_PAR=" --split 1 --index-subset $SUBSET"
 


### PR DESCRIPTION
Faced the following error while running `mmseqs createindex`:
```
Invalid mask mode. No sequence lookup created!
Error: indexdb died
```

Solves similar error faced in #766. 

`mmseqs createindex --help` mentions the following for `--index-subset`:

```
--index-subset INT           Create specialized index with subset of entries
                              0: normal index
                              1: index without headers
                              2: index without prefiltering data
                              4: index without aln (for cluster db)
                              8: no sequence lookup (good for GPU only searches)
                              Flags can be combined bit wise [0]
```

The if condition checks for the `no sequence lookup` in mmseqs but doesn't set the bit for option 8.

Currently SUBSET is set to 10 ([line 124, setup_databases.sh](https://github.com/sokrypton/ColabFold/blob/9712f2ff262d3977d571919317e06cc96c29cd95/setup_databases.sh#L124)). It works fine when I changed it to 1010