### PR TITLE
Harden retry loops in run_mmseqs2

### DIFF
--- a/colabfold/colabfold.py
+++ b/colabfold/colabfold.py
@@ -122,7 +122,7 @@ def run_mmseqs2(x, prefix, use_env=True, use_filter=True,
         logger.warning(f"Error while fetching result from MSA server. Retrying... ({error_count}/5)")
         logger.warning(f"Error: {e}")
         time.sleep(5)
-        if error_count > 5:
+        if error_count >= 5:
           raise
         continue
       break
@@ -146,7 +146,7 @@ def run_mmseqs2(x, prefix, use_env=True, use_filter=True,
         logger.warning(f"Error while fetching result from MSA server. Retrying... ({error_count}/5)")
         logger.warning(f"Error: {e}")
         time.sleep(5)
-        if error_count > 5:
+        if error_count >= 5:
           raise
         continue
       break
@@ -286,7 +286,7 @@ def run_mmseqs2(x, prefix, use_env=True, use_filter=True,
             logger.warning(f"Error while fetching result from template server. Retrying... ({error_count}/5)")
             logger.warning(f"Error: {e}")
             time.sleep(5)
-            if error_count > 5:
+            if error_count >= 5:
               raise
             continue
           break

--- a/colabfold/colabfold.py
+++ b/colabfold/colabfold.py
@@ -89,9 +89,6 @@ def run_mmseqs2(x, prefix, use_env=True, use_filter=True,
         # https://requests.readthedocs.io/en/latest/user/advanced/#advanced
         # "good practice to set connect timeouts to slightly larger than a multiple of 3"
         res = requests.post(f'{host_url}/{submission_endpoint}', data={ 'q': query, 'mode': mode }, timeout=6.02, headers=headers)
-      except requests.exceptions.Timeout:
-        logger.warning("Timeout while submitting to MSA server. Retrying...")
-        continue
       except Exception as e:
         error_count += 1
         logger.warning(f"Error while fetching result from MSA server. Retrying... ({error_count}/5)")
@@ -114,9 +111,6 @@ def run_mmseqs2(x, prefix, use_env=True, use_filter=True,
     while True:
       try:
         res = requests.get(f'{host_url}/ticket/{ID}', timeout=6.02, headers=headers)
-      except requests.exceptions.Timeout:
-        logger.warning("Timeout while fetching status from MSA server. Retrying...")
-        continue
       except Exception as e:
         error_count += 1
         logger.warning(f"Error while fetching result from MSA server. Retrying... ({error_count}/5)")
@@ -138,9 +132,6 @@ def run_mmseqs2(x, prefix, use_env=True, use_filter=True,
     while True:
       try:
         res = requests.get(f'{host_url}/result/download/{ID}', timeout=6.02, headers=headers)
-      except requests.exceptions.Timeout:
-        logger.warning("Timeout while fetching result from MSA server. Retrying...")
-        continue
       except Exception as e:
         error_count += 1
         logger.warning(f"Error while fetching result from MSA server. Retrying... ({error_count}/5)")
@@ -278,9 +269,6 @@ def run_mmseqs2(x, prefix, use_env=True, use_filter=True,
             # https://requests.readthedocs.io/en/latest/user/advanced/#advanced
             # "good practice to set connect timeouts to slightly larger than a multiple of 3"
             response = requests.get(f"{host_url}/template/{TMPL_LINE}", stream=True, timeout=6.02, headers=headers)
-          except requests.exceptions.Timeout:
-            logger.warning("Timeout while submitting to template server. Retrying...")
-            continue
           except Exception as e:
             error_count += 1
             logger.warning(f"Error while fetching result from template server. Retrying... ({error_count}/5)")

--- a/colabfold/colabfold.py
+++ b/colabfold/colabfold.py
@@ -110,8 +110,8 @@ def run_mmseqs2(x, prefix, use_env=True, use_filter=True,
     return out
 
   def status(ID):
+    error_count = 0
     while True:
-      error_count = 0
       try:
         res = requests.get(f'{host_url}/ticket/{ID}', timeout=6.02, headers=headers)
       except requests.exceptions.Timeout:
@@ -272,8 +272,8 @@ def run_mmseqs2(x, prefix, use_env=True, use_filter=True,
         os.mkdir(TMPL_PATH)
         TMPL_LINE = ",".join(TMPL[:20])
         response = None
+        error_count = 0
         while True:
-          error_count = 0
           try:
             # https://requests.readthedocs.io/en/latest/user/advanced/#advanced
             # "good practice to set connect timeouts to slightly larger than a multiple of 3"

--- a/tests/test_mmseqs_api.py
+++ b/tests/test_mmseqs_api.py
@@ -3,7 +3,9 @@
 Each of the four retry loops in run_mmseqs2 (submit, status, download, templates)
 caps at a fixed number of attempts. status() and the templates loop used to
 reset their counter inside the loop, which silently turned them into
-unbounded retries — these tests pin the bounded behavior.
+unbounded retries; the Timeout branch used to retry without sleeping or
+counting, also unbounded. These tests pin the bounded behavior across both
+failure modes.
 """
 
 import pytest
@@ -14,6 +16,11 @@ from colabfold.colabfold import run_mmseqs2
 # Safety bound so a regression to unbounded retries fails fast instead of
 # spinning forever (time.sleep is monkeypatched to a no-op below).
 MAX_RETRY_CALLS = 50
+
+FAILURE_MODES = [
+    pytest.param(requests.exceptions.ConnectionError, id="connection-error"),
+    pytest.param(requests.exceptions.Timeout, id="timeout"),
+]
 
 
 class JsonResponse:
@@ -26,7 +33,7 @@ class JsonResponse:
         return self.payload
 
 
-def _failing_get(calls, message):
+def _failing_get(calls, exc_cls, message):
     def get(*args, **kwargs):
         calls["get"] += 1
         if calls["get"] > MAX_RETRY_CALLS:
@@ -34,12 +41,40 @@ def _failing_get(calls, message):
                 f"retry loop exceeded {MAX_RETRY_CALLS} calls — "
                 "the bound on retries has regressed"
             )
-        raise requests.exceptions.ConnectionError(message)
+        raise exc_cls(message)
 
     return get
 
 
-def test_status_retries_are_bounded(monkeypatch, tmp_path):
+@pytest.mark.parametrize("exc_cls", FAILURE_MODES)
+def test_submit_retries_are_bounded(monkeypatch, tmp_path, exc_cls):
+    calls = {"post": 0}
+
+    def post(*args, **kwargs):
+        calls["post"] += 1
+        if calls["post"] > MAX_RETRY_CALLS:
+            raise AssertionError(
+                f"retry loop exceeded {MAX_RETRY_CALLS} calls — "
+                "the bound on retries has regressed"
+            )
+        raise exc_cls("submit failed")
+
+    monkeypatch.setattr("colabfold.colabfold.requests.post", post)
+    monkeypatch.setattr("colabfold.colabfold.time.sleep", lambda _s: None)
+
+    with pytest.raises(exc_cls, match="submit failed"):
+        run_mmseqs2(
+            "ACDE",
+            str(tmp_path / "msa"),
+            use_env=False,
+            user_agent="colabfold/test",
+        )
+
+    assert calls["post"] == 5
+
+
+@pytest.mark.parametrize("exc_cls", FAILURE_MODES)
+def test_status_retries_are_bounded(monkeypatch, tmp_path, exc_cls):
     calls = {"get": 0}
 
     monkeypatch.setattr(
@@ -48,11 +83,11 @@ def test_status_retries_are_bounded(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(
         "colabfold.colabfold.requests.get",
-        _failing_get(calls, "status failed"),
+        _failing_get(calls, exc_cls, "status failed"),
     )
     monkeypatch.setattr("colabfold.colabfold.time.sleep", lambda _s: None)
 
-    with pytest.raises(requests.exceptions.ConnectionError, match="status failed"):
+    with pytest.raises(exc_cls, match="status failed"):
         run_mmseqs2(
             "ACDE",
             str(tmp_path / "msa"),
@@ -63,7 +98,8 @@ def test_status_retries_are_bounded(monkeypatch, tmp_path):
     assert calls["get"] == 5
 
 
-def test_download_retries_are_bounded(monkeypatch, tmp_path):
+@pytest.mark.parametrize("exc_cls", FAILURE_MODES)
+def test_download_retries_are_bounded(monkeypatch, tmp_path, exc_cls):
     calls = {"get": 0}
 
     monkeypatch.setattr(
@@ -72,11 +108,11 @@ def test_download_retries_are_bounded(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(
         "colabfold.colabfold.requests.get",
-        _failing_get(calls, "download failed"),
+        _failing_get(calls, exc_cls, "download failed"),
     )
     monkeypatch.setattr("colabfold.colabfold.time.sleep", lambda _s: None)
 
-    with pytest.raises(requests.exceptions.ConnectionError, match="download failed"):
+    with pytest.raises(exc_cls, match="download failed"):
         run_mmseqs2(
             "ACDE",
             str(tmp_path / "msa"),
@@ -87,7 +123,8 @@ def test_download_retries_are_bounded(monkeypatch, tmp_path):
     assert calls["get"] == 5
 
 
-def test_templates_retries_are_bounded(monkeypatch, tmp_path):
+@pytest.mark.parametrize("exc_cls", FAILURE_MODES)
+def test_templates_retries_are_bounded(monkeypatch, tmp_path, exc_cls):
     # Pre-create the MSA-stage artifacts so run_mmseqs2 skips submit/status/
     # download (tar_gz_file exists) and a3m extraction (uniref.a3m exists),
     # going straight to the templates fetch we want to exercise.
@@ -102,11 +139,11 @@ def test_templates_retries_are_bounded(monkeypatch, tmp_path):
     calls = {"get": 0}
     monkeypatch.setattr(
         "colabfold.colabfold.requests.get",
-        _failing_get(calls, "template failed"),
+        _failing_get(calls, exc_cls, "template failed"),
     )
     monkeypatch.setattr("colabfold.colabfold.time.sleep", lambda _s: None)
 
-    with pytest.raises(requests.exceptions.ConnectionError, match="template failed"):
+    with pytest.raises(exc_cls, match="template failed"):
         run_mmseqs2(
             "ACDE",
             str(tmp_path / "msa"),

--- a/tests/test_mmseqs_api.py
+++ b/tests/test_mmseqs_api.py
@@ -1,0 +1,118 @@
+"""Regression tests for the run_mmseqs2 retry loops.
+
+Each of the four retry loops in run_mmseqs2 (submit, status, download, templates)
+caps at a fixed number of attempts. status() and the templates loop used to
+reset their counter inside the loop, which silently turned them into
+unbounded retries — these tests pin the bounded behavior.
+"""
+
+import pytest
+import requests
+
+from colabfold.colabfold import run_mmseqs2
+
+# Safety bound so a regression to unbounded retries fails fast instead of
+# spinning forever (time.sleep is monkeypatched to a no-op below).
+MAX_RETRY_CALLS = 50
+
+
+class JsonResponse:
+    def __init__(self, payload):
+        self.payload = payload
+        self.text = str(payload)
+        self.content = b""
+
+    def json(self):
+        return self.payload
+
+
+def _failing_get(calls, message):
+    def get(*args, **kwargs):
+        calls["get"] += 1
+        if calls["get"] > MAX_RETRY_CALLS:
+            raise AssertionError(
+                f"retry loop exceeded {MAX_RETRY_CALLS} calls — "
+                "the bound on retries has regressed"
+            )
+        raise requests.exceptions.ConnectionError(message)
+
+    return get
+
+
+def test_status_retries_are_bounded(monkeypatch, tmp_path):
+    calls = {"get": 0}
+
+    monkeypatch.setattr(
+        "colabfold.colabfold.requests.post",
+        lambda *a, **kw: JsonResponse({"status": "RUNNING", "id": "job-id"}),
+    )
+    monkeypatch.setattr(
+        "colabfold.colabfold.requests.get",
+        _failing_get(calls, "status failed"),
+    )
+    monkeypatch.setattr("colabfold.colabfold.time.sleep", lambda _s: None)
+
+    with pytest.raises(requests.exceptions.ConnectionError, match="status failed"):
+        run_mmseqs2(
+            "ACDE",
+            str(tmp_path / "msa"),
+            use_env=False,
+            user_agent="colabfold/test",
+        )
+
+    assert calls["get"] == 6
+
+
+def test_download_retries_are_bounded(monkeypatch, tmp_path):
+    calls = {"get": 0}
+
+    monkeypatch.setattr(
+        "colabfold.colabfold.requests.post",
+        lambda *a, **kw: JsonResponse({"status": "COMPLETE", "id": "job-id"}),
+    )
+    monkeypatch.setattr(
+        "colabfold.colabfold.requests.get",
+        _failing_get(calls, "download failed"),
+    )
+    monkeypatch.setattr("colabfold.colabfold.time.sleep", lambda _s: None)
+
+    with pytest.raises(requests.exceptions.ConnectionError, match="download failed"):
+        run_mmseqs2(
+            "ACDE",
+            str(tmp_path / "msa"),
+            use_env=False,
+            user_agent="colabfold/test",
+        )
+
+    assert calls["get"] == 6
+
+
+def test_templates_retries_are_bounded(monkeypatch, tmp_path):
+    # Pre-create the MSA-stage artifacts so run_mmseqs2 skips submit/status/
+    # download (tar_gz_file exists) and a3m extraction (uniref.a3m exists),
+    # going straight to the templates fetch we want to exercise.
+    msa_dir = tmp_path / "msa_all"
+    msa_dir.mkdir()
+    (msa_dir / "out.tar.gz").write_bytes(b"")
+    (msa_dir / "uniref.a3m").write_text(">seq1\nACDE\n")
+    (msa_dir / "pdb70.m8").write_text(
+        "101\t1abc_A\t50.0\t100\t10\t1\t1\t100\t1\t100\t1e-10\t100.0\n"
+    )
+
+    calls = {"get": 0}
+    monkeypatch.setattr(
+        "colabfold.colabfold.requests.get",
+        _failing_get(calls, "template failed"),
+    )
+    monkeypatch.setattr("colabfold.colabfold.time.sleep", lambda _s: None)
+
+    with pytest.raises(requests.exceptions.ConnectionError, match="template failed"):
+        run_mmseqs2(
+            "ACDE",
+            str(tmp_path / "msa"),
+            use_env=False,
+            use_templates=True,
+            user_agent="colabfold/test",
+        )
+
+    assert calls["get"] == 6

--- a/tests/test_mmseqs_api.py
+++ b/tests/test_mmseqs_api.py
@@ -60,7 +60,7 @@ def test_status_retries_are_bounded(monkeypatch, tmp_path):
             user_agent="colabfold/test",
         )
 
-    assert calls["get"] == 6
+    assert calls["get"] == 5
 
 
 def test_download_retries_are_bounded(monkeypatch, tmp_path):
@@ -84,7 +84,7 @@ def test_download_retries_are_bounded(monkeypatch, tmp_path):
             user_agent="colabfold/test",
         )
 
-    assert calls["get"] == 6
+    assert calls["get"] == 5
 
 
 def test_templates_retries_are_bounded(monkeypatch, tmp_path):
@@ -115,4 +115,4 @@ def test_templates_retries_are_bounded(monkeypatch, tmp_path):
             user_agent="colabfold/test",
         )
 
-    assert calls["get"] == 6
+    assert calls["get"] == 5


### PR DESCRIPTION
## Summary

Three small fixes to `run_mmseqs2` in `colabfold/colabfold.py` so the retry
behavior matches what the `"(N/5)"` log message implies and what `submit()`
already does:

1. **Fix unbounded retries in `status()` and the template fetch.** Both reset
   `error_count = 0` inside `while True:`, so the `if error_count > 5: raise`
   guard was unreachable — a persistent connection error retried forever.
   Moved the counter outside the loop.

2. **Match the cap to 5 attempts everywhere.** `status()`, `download()`, and
   the template fetch used `error_count > 5`, attempting 6 times before
   raising. Changed to `>= 5` to match `submit()` and the logged `(N/5)`
   limit.

3. **Drop the `except requests.exceptions.Timeout:` branches.** All four did
   `continue` without incrementing `error_count` and without `time.sleep`,
   so a persistent timeout retried forever in a tight loop. `Timeout` is an
   `Exception` subclass, so removing the narrower handler lets it fall
   through to the general one that already increments the counter, sleeps,
   and honors the cap.

### Behavior change worth calling out

Before this PR, two of the four retry loops (`status()` and the templates
fetch) silently retried forever on a persistent connection error, and all
four did so on a persistent timeout. After the PR, all four cap at 5
attempts with a 5-second sleep between them, matching the existing
`submit()` semantics and the on-screen `(N/5)` progress message.

Users on very flaky networks who were unknowingly benefiting from the
unbounded retries will now see jobs fail loudly rather than hang. The
pre-PR behavior looks like an oversight rather than an intentional design
choice, but flagging explicitly so you can weigh in.

## Tests

Added `tests/test_mmseqs_api.py` covering all four retry sites, parametrized
over both failure modes (`ConnectionError` and `Timeout`) — 8 cases total.
Each test monkeypatches `requests` to fail persistently and asserts the
call count hits exactly 5 before the exception propagates. A safety bound
(`MAX_RETRY_CALLS = 50`) in the mock makes any future regression to
unbounded retries fail fast with a clear `AssertionError` instead of
hanging the suite.

## Notes

Happy to squash the three commits into one if you'd prefer. Kept them
separate because the bug fix (commit 1) is uncontroversial while commits 2
and 3 are minor behavior changes — splitting makes them easier to take or
drop independently.

## Test plan

- [x] `pytest tests/test_mmseqs_api.py` — all 8 cases pass under Python 3.11 and 3.12
- [ ] Full project test suite (requires the `alphafold` extras; relying on CI)