### PR TITLE
Pass default MMseqs k-score without shell quotes

### DIFF
--- a/colabfold/mmseqs/search.py
+++ b/colabfold/mmseqs/search.py
@@ -120,7 +120,7 @@ def mmseqs_search_monomer(
         if s is not None: # sensitivy can only be set for non-gpu version, gpu version runs at max sensitivity
             search_param += ["-s", "{:.1f}".format(s)]
         else:
-            search_param += ["--k-score", "'seq:96,prof:80'"]
+            search_param += ["--k-score", "seq:96,prof:80"]
     if gpu_server:
         search_param += ["--gpu-server", str(gpu_server)]
 
@@ -260,7 +260,7 @@ def mmseqs_search_pair(
         if s is not None: # sensitivy can only be set for non-gpu version, gpu version runs at max sensitivity
             search_param += ["-s", "{:.1f}".format(s)]
         else:
-            search_param += ["--k-score", "'seq:96,prof:80'"]
+            search_param += ["--k-score", "seq:96,prof:80"]
     if gpu_server:
         search_param += ["--gpu-server", str(gpu_server)]
     expand_param = ["--expansion-mode", "0", "-e", "inf", "--expand-filter-clusters", "0", "--max-seq-id", "0.95",]

--- a/tests/test_mmseqs_search.py
+++ b/tests/test_mmseqs_search.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+
+from colabfold.mmseqs import search
+
+
+def _touch_db(dbbase: Path, name: str) -> None:
+    dbbase.joinpath(f"{name}.dbtype").touch()
+    dbbase.joinpath(f"{name}.idx").touch()
+
+
+def _capture_mmseqs_calls(monkeypatch):
+    calls = []
+
+    def fake_run_mmseqs(mmseqs, params):
+        calls.append([str(param) for param in params])
+
+    monkeypatch.setattr(search, "run_mmseqs", fake_run_mmseqs)
+    return calls
+
+
+def _assert_default_k_score_is_unquoted(calls):
+    search_calls = [call for call in calls if call[0] == "search"]
+    assert len(search_calls) == 1
+
+    search_call = search_calls[0]
+    assert "'seq:96,prof:80'" not in search_call
+    assert search_call[search_call.index("--k-score") + 1] == "seq:96,prof:80"
+
+
+def test_monomer_search_default_k_score_is_passed_without_shell_quotes(
+    monkeypatch, tmp_path
+):
+    dbbase = tmp_path.joinpath("db")
+    base = tmp_path.joinpath("work")
+    dbbase.mkdir()
+    base.mkdir()
+    base.joinpath("tmp").mkdir()
+    _touch_db(dbbase, "uniref30_2302_db")
+    calls = _capture_mmseqs_calls(monkeypatch)
+
+    search.mmseqs_search_monomer(
+        dbbase=dbbase,
+        base=base,
+        use_env=False,
+        use_templates=False,
+        s=None,
+        threads=1,
+        unpack=False,
+    )
+
+    _assert_default_k_score_is_unquoted(calls)
+
+
+def test_pair_search_default_k_score_is_passed_without_shell_quotes(
+    monkeypatch, tmp_path
+):
+    dbbase = tmp_path.joinpath("db")
+    base = tmp_path.joinpath("work")
+    dbbase.mkdir()
+    base.mkdir()
+    base.joinpath("tmp").mkdir()
+    _touch_db(dbbase, "uniref30_2302_db")
+    calls = _capture_mmseqs_calls(monkeypatch)
+
+    search.mmseqs_search_pair(
+        dbbase=dbbase,
+        base=base,
+        pair_env=False,
+        s=None,
+        threads=1,
+        unpack=False,
+    )
+
+    _assert_default_k_score_is_unquoted(calls)


### PR DESCRIPTION
## Summary

- Pass the default local MMseqs `--k-score` value as `seq:96,prof:80` instead of including literal shell quotes.
- Add regression coverage for both monomer and paired local search command construction.

## Root Cause

`colabfold_search` builds MMseqs commands as a Python argument list and calls `subprocess.check_call` without a shell. The existing `"'seq:96,prof:80'"` value therefore reaches MMseqs with the single quote characters still attached, so MMseqs does not apply the intended TWIN value and falls back to its default `seq:2147483647,prof:2147483647`.

## Local Reproduction

We reproduced this in a local ColabFold 1.6.1 CPU deployment using the standard `colabfold_search` path with no explicit `-s` and no `--gpu`.

Current behavior:

- ColabFold logs `--k-score 'seq:96,prof:80'`
- MMseqs prefilter receives fallback `--k-score seq:2147483647,prof:2147483647`
- Observed k-mer similarity threshold: `122`

Patched behavior:

- MMseqs receives `--k-score seq:96,prof:80`
- Observed thresholds: `96` for sequence search and `80` for profile search

On a 20-protein stratified sample, 15/20 final A3Ms changed. Row-count impact was modest:

- Median patched/old row ratio: `0.996`
- Max patched/old row ratio: `1.022`
- Min patched/old row ratio: `0.858`

The patched path was more computationally expensive in this sample, especially environmental prefiltering.

## Impact

This affects default local CPU searches where sensitivity is omitted (`-s` is `None`) and GPU search is not used. In that path ColabFold intends to match the server-like default k-mer threshold directly, but the quoted argument prevents MMseqs from receiving it correctly.

Fixes #804.

## Validation

- `python -m pytest tests/test_mmseqs_search.py -q`
- `python -m py_compile colabfold/mmseqs/search.py tests/test_mmseqs_search.py`
- `git diff --check`

I also attempted to include `tests/test_msa.py` locally, but this checkout's venv still lacks the optional `alphafold` dependency required to collect that test module.